### PR TITLE
Set sonatypeProfileName for publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,8 @@ inThisBuild(List(
   )
 ))
 
+sonatypeProfileName := "io.github.alexarchambault"
+
 enablePlugins(ScriptedPlugin)
 sbtPlugin := true
 scriptedLaunchOpts += "-Dplugin.version=" + version.value


### PR DESCRIPTION
It's different than `organization`, which confuses sbt-sonatype